### PR TITLE
Fixed FLASK_DEBUG in docker-compose

### DIFF
--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -14,7 +14,7 @@ services:
     command: sleep infinity
     environment:
       FLASK_APP: service:app
-      FLASK_DEBUG: True
+      FLASK_DEBUG: "True"
       PORT: 8000
       DATABASE_URI: postgresql://postgres:postgres@postgres:5432/postgres
     networks:


### PR DESCRIPTION
Fix: Environment variable "FLASK_DEBUG" correctly set to "True"