### PR TITLE
Query by quantity

### DIFF
--- a/service/models.py
+++ b/service/models.py
@@ -223,4 +223,3 @@ class Inventory(db.Model):
         if not quantity.isdigit():
             raise DataValidationError("Invalid quantity in query: " + str(quantity))
         return cls.query.filter(cls.quantity == int(quantity))
-    

--- a/service/models.py
+++ b/service/models.py
@@ -211,3 +211,16 @@ class Inventory(db.Model):
         if restock == "true":
             return cls.query.filter(cls.quantity <= cls.restock_level)
         return cls.query.filter(cls.quantity > cls.restock_level)
+
+    @classmethod
+    def find_by_quantity(cls, quantity):
+        """Returns all inventory items with the given quantity
+
+        Args:
+            quantity (string): a string that must be able to be converted into an integer
+        """
+        logger.info("Processing quantity query for %s ...", quantity)
+        if not quantity.isdigit():
+            raise DataValidationError("Invalid quantity in query: " + str(quantity))
+        return cls.query.filter(cls.quantity == int(quantity))
+    

--- a/service/routes.py
+++ b/service/routes.py
@@ -157,10 +157,14 @@ def list_inventory_items():
     items = []
     condition = request.args.get("condition")
     restock = request.args.get("restock")
+    quantity = request.args.get("quantity")
     if condition:
         items = Inventory.find_by_condition(condition)
     elif restock:
         items = Inventory.find_by_restock_level(restock)
+    elif quantity is not None: 
+        # The case where quantity query is an empty string is handled in models.py
+        items = Inventory.find_by_quantity(quantity)
     else:
         items = Inventory.all()
     results = [item.serialize() for item in items]

--- a/service/routes.py
+++ b/service/routes.py
@@ -162,8 +162,7 @@ def list_inventory_items():
         items = Inventory.find_by_condition(condition)
     elif restock:
         items = Inventory.find_by_restock_level(restock)
-    elif quantity is not None: 
-        # The case where quantity query is an empty string is handled in models.py
+    elif quantity:
         items = Inventory.find_by_quantity(quantity)
     else:
         items = Inventory.all()

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -344,7 +344,7 @@ class TestInventoryModel(unittest.TestCase):
         for item in found:
             self.assertEqual(item.quantity, target_quantity)
 
-    def test_find_by_quantity_invalid_query(self):
+    def test_find_by_quantity_invalid_quantity(self):
         """It should not query Inventory items by a invalid quantity"""
         items = InventoryFactory.create_batch(10)
         for item in items:
@@ -358,3 +358,4 @@ class TestInventoryModel(unittest.TestCase):
         self.assertRaises(DataValidationError, Inventory.find_by_condition, "134.00")
         self.assertRaises(DataValidationError, Inventory.find_by_condition, ".134")
         self.assertRaises(DataValidationError, Inventory.find_by_condition, "134d")
+        self.assertRaises(DataValidationError, Inventory.find_by_condition, "")

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -4,7 +4,6 @@ Test cases for Inventory Model
 """
 import os
 import logging
-import random
 import unittest
 from datetime import datetime
 from service.models import Inventory, Condition, DataValidationError, db

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -413,7 +413,7 @@ class TestInventoryServer(TestCase):
         """Querying list all with invalid quantity should return 400"""
         test_quantity_list = [
             "damage", "-100", "+100", "d123", "d", 
-            "134.42", "134.00", ".134", "134d", ""
+            "134.42", "134.00", ".134", "134d"
         ]
         for test_quantity in test_quantity_list:
             response = self.client.get(

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -257,6 +257,22 @@ class TestInventoryServer(TestCase):
         for item in data:
             self.assertGreater(item["quantity"], item["restock_level"])
 
+    def test_query_item_by_quantity(self):
+        """It should Query Inventory Items by quantity"""
+        items = self._create_items(10)
+        test_quantity = items[0].quantity
+        quantity_items = [item for item in items if item.quantity == test_quantity]
+        response = self.client.get(
+            BASE_URL,
+            query_string=f"quantity={quote_plus(str(test_quantity))}"
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        data = response.get_json()
+        self.assertEqual(len(data), len(quantity_items))
+        # check the data just to be sure
+        for item in data:
+            self.assertEqual(item["quantity"], test_quantity)
+
     ######################################################################
     #  T E S T   S A D   P A T H S
     ######################################################################
@@ -392,3 +408,16 @@ class TestInventoryServer(TestCase):
             query_string=f"condition={quote_plus(test_condition)}"
         )
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_query_item_by_quantity_invalid_quantity(self):
+        """Querying list all with invalid quantity should return 400"""
+        test_quantity_list = [
+            "damage", "-100", "+100", "d123", "d", 
+            "134.42", "134.00", ".134", "134d", ""
+        ]
+        for test_quantity in test_quantity_list:
+            response = self.client.get(
+                BASE_URL,
+                query_string=f"quantity={quote_plus(test_quantity)}"
+            )
+            self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -412,7 +412,7 @@ class TestInventoryServer(TestCase):
     def test_query_item_by_quantity_invalid_quantity(self):
         """Querying list all with invalid quantity should return 400"""
         test_quantity_list = [
-            "damage", "-100", "+100", "d123", "d", 
+            "damage", "-100", "+100", "d123", "d",
             "134.42", "134.00", ".134", "134d"
         ]
         for test_quantity in test_quantity_list:


### PR DESCRIPTION
- Add query by quantity (and corresponding test cases) in `models.py`
- Add query by quantity endpoints (and corresponding test cases) in `routes.py`

Current version: an valid query string must contains **ONLY** digits (positive integer). Therefore, the following query strings are **NOT** valid, among a lot of others: "+100", "-100", "100.00". Please comment if this behavior needs to be changed.