### PR TITLE
init commit: add 200 ok status to restock in API docs

### DIFF
--- a/service/routes.py
+++ b/service/routes.py
@@ -230,6 +230,7 @@ class RestockResource(Resource):
     @api.doc('restock_item')
     @api.response(404, 'Inventory Item not found')
     @api.response(409, 'The item quantity is above restock level')
+    @api.marshal_with(inventory_model)
     def put(self, inventory_id):
         """
         Restock an existing inventory item


### PR DESCRIPTION
- fix the issue that the "200 status" is not listed as a response in API docs for restock action

Now it looks like the following:
![image](https://user-images.githubusercontent.com/28769754/235781046-77f82c6f-6e7c-4e46-af38-c30f776abb11.png)
